### PR TITLE
Modify webpack.config.js so output.path matches output.publicPath.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './scripts/index'
   ],
   output: {
-    path: __dirname,
+    path: __dirname + '/scripts/',
     filename: 'bundle.js',
     publicPath: '/scripts/'
   },


### PR DESCRIPTION
This is a minor fix that I noticed while using react-hot-boilerplate as a guide to enable hot loading on my own project.

Thanks for a great example!

Problem
-------

Running webpack at the command line generates ./bundle.js. However, index.html expects /scripts/bundle.js (where the dev server serves it).

Fix
------

Append '/scripts/' to output.path in webpack.config. This will create a scripts directory and place bundle.js in it when running `webpack` at the CLI.