### PR TITLE
Don't use NoErrorsPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/scripts/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   resolve: {
     extensions: ['', '.js', '.jsx']


### PR DESCRIPTION
With `hot/only-dev-server`, it is not needed! In fact, if you remove it, you will have the same workflow, but also see the syntax errors in browser console.

![screen shot 2015-05-23 at 1 23 05](https://cloud.githubusercontent.com/assets/810438/7780647/4b296f22-00ea-11e5-959b-2c7d2d323214.png)
