### PR TITLE
Revert "Don't use NoErrorsPlugin"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,8 @@ module.exports = {
     publicPath: '/scripts/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
   ],
   resolve: {
     extensions: ['', '.js', '.jsx']


### PR DESCRIPTION
Reverts gaearon/react-hot-boilerplate#22

It seems like removing `NoErrorsPlugin` causes HMR to break if you misspell an `import`. I'll ask around in Webpack repo for some middle solution that solves both problems, but for now, let's keep `NoErrorsPlugin`.