### PR TITLE
Add playground for React Hot Loader 2

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-  "stage": 0
+  "stage": 0,
+  "plugins": [
+    "babel-plugin-react-display-name",
+    "babel-plugin-wrap-react-components"
+  ],
+  "extra": {
+    "babel-plugin-wrap-react-components": {
+      "wrap": "my-custom-transform-see-webpack-config"
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,47 +1,4 @@
 react-hot-boilerplate
 =====================
 
-The minimal dev environment to enable live-editing React components.
-
-### Usage
-
-```
-npm install
-npm start
-open http://localhost:3000
-```
-
-Now edit `src/App.js`.  
-Your changes will appear without reloading the browser like in [this video](http://vimeo.com/100010922).
-
-### Linting
-
-This boilerplate project includes React-friendly ESLint configuration.
-
-```
-npm run lint
-```
-
-### Using `0.0.0.0` as Host
-
-You may want to change the host in `server.js` and `webpack.config.js` from `localhost` to `0.0.0.0` to allow access from same WiFi network. This is not enabled by default because it is reported to cause problems on Windows. This may also be useful if you're using a VM.
-
-### Missing Features
-
-This boilerplate is purposefully simple to show the minimal configuration for React Hot Loader. For a real project, you'll want to add a separate config for production with hot reloading disabled and minification enabled. You'll also want to add a router, styles and maybe combine dev server with an existing server. This is out of scope of this boilerplate, but you may want to look into [other starter kits](https://github.com/gaearon/react-hot-loader/blob/master/docs/README.md#starter-kits).
-
-### Dependencies
-
-* React
-* Webpack
-* [webpack-dev-server](https://github.com/webpack/webpack-dev-server)
-* [babel-loader](https://github.com/babel/babel-loader)
-* [react-hot-loader](https://github.com/gaearon/react-hot-loader)
-
-### Resources
-
-* [Demo video](http://vimeo.com/100010922)
-* [react-hot-loader on Github](https://github.com/gaearon/react-hot-loader)
-* [Integrating JSX live reload into your workflow](http://gaearon.github.io/react-hot-loader/getstarted/)
-* [Troubleshooting guide](https://github.com/gaearon/react-hot-loader/blob/master/docs/Troubleshooting.md)
-* Ping dan_abramov on Twitter or #reactjs IRC
+This branch is a playground for the future version of React Hot Loader. Right now it doesn't even use it.

--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.2",
     "eslint-plugin-react": "^2.3.0",
-    "react-hot-loader": "^1.2.7",
+    "react-proxy": "^0.6.3",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2"
   },
   "dependencies": {
+    "autobind-decorator": "^1.3.1",
     "react": "^0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.2",
     "babel-plugin-react-display-name": "^2.0.0",
-    "babel-plugin-wrap-react-components": "^2.0.1",
+    "babel-plugin-wrap-react-components": "^3.0.0",
     "eslint-plugin-react": "^2.3.0",
     "react-hot-loader": "^2.0.0-alpha-4",
     "react-proxy": "^0.6.7",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-plugin-react-display-name": "^2.0.0",
     "babel-plugin-wrap-react-components": "^2.0.1",
     "eslint-plugin-react": "^2.3.0",
+    "react-hot-loader": "^2.0.0-alpha-4",
     "react-proxy": "^0.6.7",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.2",
     "babel-plugin-react-display-name": "^2.0.0",
-    "babel-plugin-wrap-react-components": "^3.0.0",
+    "babel-plugin-wrap-react-components": "^4.0.0",
     "eslint-plugin-react": "^2.3.0",
     "react-hot-loader": "^2.0.0-alpha-4",
     "react-proxy": "^0.6.7",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "babel-core": "^5.4.7",
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.2",
+    "babel-plugin-react-display-name": "^2.0.0",
+    "babel-plugin-wrap-react-components": "^2.0.1",
     "eslint-plugin-react": "^2.3.0",
-    "react-proxy": "^0.6.3",
+    "react-proxy": "^0.6.7",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,3 @@
-import React, { Component } from 'react';
-import autobind from 'autobind-decorator';
-
 // In this demo, we show two things:
 
 // - You can edit classes even though they're not exported
@@ -19,6 +16,15 @@ import autobind from 'autobind-decorator';
 // Note how wrappers are composable and can be distributed on NPM
 // as separate packages.
 
+import { shouldAcceptFilename } from './transforms/hotify';
+if (shouldAcceptFilename(__filename)) {
+  module.hot.accept();
+}
+
+import React, { Component } from 'react';
+import autobind from 'autobind-decorator';
+import { TimerA, TimerB } from './timers';
+
 var RandomNumber = React.createClass({
   componentWillMount() {
     this.num = Math.random();
@@ -28,60 +34,6 @@ var RandomNumber = React.createClass({
     return <div>Random number: {this.num}</div>
   }
 });
-
-class TimerA extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { counter: 0 };
-    this.interval = setInterval(() => this.tick(), 1000);
-  }
-
-  tick() {
-    this.setState({
-      counter: this.state.counter + 1
-    });
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    return (
-      <div style={{ color: 'red' }}>
-        <h2>{this.props.children}</h2>
-        <h3>TimerA state: {this.state.counter}</h3>
-      </div>
-    );
-  }
-}
-
-class TimerB extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { counter: 0 };
-    this.interval = setInterval(() => this.tick(), 300);
-  }
-
-  tick() {
-    this.setState({
-      counter: this.state.counter + 1
-    });
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    return (
-      <div style={{ color: 'blue' }}>
-        <h2>{this.props.children}</h2>
-        <h3>TimerB state: {this.state.counter}</h3>
-      </div>
-    );
-  }
-}
 
 export default class App extends Component {
   render() {
@@ -94,5 +46,3 @@ export default class App extends Component {
     );
   }
 }
-
-module.hot.accept();

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,35 @@
 import React, { Component } from 'react';
 import autobind from 'autobind-decorator';
-import hot from './hot';
 
-@hot('RendererA')
-class RendererA extends Component {
+// In this demo, we show two things:
+
+// - You can edit classes even though they're not exported
+// - You can throw errors inside render() method and they'll be handled
+
+// We achieve this by using babel-plugin-wrap-react-components
+// to find all React components, and configuring it via .babelrc
+// to use a custom wrapper function.
+
+// Our wrapper function is defined in transforms/index.js.
+// It delegates to two different wrappers:
+
+// - hotify uses react-proxy to hot reload components
+// - catchRenderErrors.. well, catches render errors
+
+// Note how wrappers are composable and can be distributed on NPM
+// as separate packages.
+
+var RandomNumber = React.createClass({
+  componentWillMount() {
+    this.num = Math.random();
+  },
+
+  render() {
+    return <div>Random number: {this.num}</div>
+  }
+});
+
+class TimerA extends Component {
   constructor(props) {
     super(props);
     this.state = { counter: 0 };
@@ -20,10 +46,9 @@ class RendererA extends Component {
     clearInterval(this.interval);
   }
 
-  // Feel free to edit this
   render() {
     return (
-      <div style={{ color: 'green' }}>
+      <div style={{ color: 'red' }}>
         <h2>{this.props.children}</h2>
         <h3>Renderer own state: {this.state.counter}</h3>
       </div>
@@ -31,12 +56,11 @@ class RendererA extends Component {
   }
 }
 
-@hot('RendererB')
-class RendererB extends Component {
+class TimerB extends Component {
   constructor(props) {
     super(props);
     this.state = { counter: 0 };
-    this.interval = setInterval(() => this.tick(), 1000);
+    this.interval = setInterval(() => this.tick(), 300);
   }
 
   tick() {
@@ -49,7 +73,6 @@ class RendererB extends Component {
     clearInterval(this.interval);
   }
 
-  // Feel free to edit this
   render() {
     return (
       <div style={{ color: 'blue' }}>
@@ -60,59 +83,13 @@ class RendererB extends Component {
   }
 }
 
-function makeSomething(Renderer, speed) {
-  return class Something extends Component {
-    constructor(props) {
-      super(props);
-      this.state = { counter: 0 };
-    }
-
-    componentDidMount() {
-      this.tick();
-    }
-
-    componentWillUnmount() {
-      clearTimeout(this.timeout);
-    }
-
-    @autobind
-    tick() {
-      this.setState({
-        counter: this.state.counter + 1
-      }, () => {
-        this.timeout = setTimeout(this.tick, speed);
-      });
-    }
-
-    // Feel free to edit this
-    render() {
-      return (
-        <div>
-          <Renderer>HOC state: {this.state.counter}</Renderer>
-        </div>
-      );
-    }
-  };
-}
-
-let Something1 = hot('makeSomething$Something1')(
-  // Feel free to edit this
-  makeSomething(RendererA, 100)
-);
-let Something2 = hot('makeSomething$Something2')(
-  // Feel free to edit this
-  makeSomething(RendererB, 100)
-);
-
-@hot('App')
 export default class App extends Component {
-  // Feel free to edit this
   render() {
     return (
       <div>
-        <Something1 />
-        <Something2 />
-        nice uh
+        <TimerA />
+        <TimerB />
+        <RandomNumber />
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ class TimerA extends Component {
     return (
       <div style={{ color: 'red' }}>
         <h2>{this.props.children}</h2>
-        <h3>Renderer own state: {this.state.counter}</h3>
+        <h3>TimerA state: {this.state.counter}</h3>
       </div>
     );
   }
@@ -77,7 +77,7 @@ class TimerB extends Component {
     return (
       <div style={{ color: 'blue' }}>
         <h2>{this.props.children}</h2>
-        <h3>Renderer own state: {this.state.counter}</h3>
+        <h3>TimerB state: {this.state.counter}</h3>
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,121 @@
 import React, { Component } from 'react';
+import autobind from 'autobind-decorator';
+import hot from './hot';
 
-export default class App extends Component {
+@hot('RendererA')
+class RendererA extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { counter: 0 };
+    this.interval = setInterval(() => this.tick(), 1000);
+  }
+
+  tick() {
+    this.setState({
+      counter: this.state.counter + 1
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  // Feel free to edit this
   render() {
     return (
-      <h1>Hello, world.</h1>
+      <div style={{ color: 'green' }}>
+        <h2>{this.props.children}</h2>
+        <h3>Renderer own state: {this.state.counter}</h3>
+      </div>
     );
   }
 }
+
+@hot('RendererB')
+class RendererB extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { counter: 0 };
+    this.interval = setInterval(() => this.tick(), 1000);
+  }
+
+  tick() {
+    this.setState({
+      counter: this.state.counter + 1
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  // Feel free to edit this
+  render() {
+    return (
+      <div style={{ color: 'blue' }}>
+        <h2>{this.props.children}</h2>
+        <h3>Renderer own state: {this.state.counter}</h3>
+      </div>
+    );
+  }
+}
+
+function makeSomething(Renderer, speed) {
+  return class Something extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    componentDidMount() {
+      this.tick();
+    }
+
+    componentWillUnmount() {
+      clearTimeout(this.timeout);
+    }
+
+    @autobind
+    tick() {
+      this.setState({
+        counter: this.state.counter + 1
+      }, () => {
+        this.timeout = setTimeout(this.tick, speed);
+      });
+    }
+
+    // Feel free to edit this
+    render() {
+      return (
+        <div>
+          <Renderer>HOC state: {this.state.counter}</Renderer>
+        </div>
+      );
+    }
+  };
+}
+
+let Something1 = hot('makeSomething$Something1')(
+  // Feel free to edit this
+  makeSomething(RendererA, 100)
+);
+let Something2 = hot('makeSomething$Something2')(
+  // Feel free to edit this
+  makeSomething(RendererB, 100)
+);
+
+@hot('App')
+export default class App extends Component {
+  // Feel free to edit this
+  render() {
+    return (
+      <div>
+        <Something1 />
+        <Something2 />
+        nice uh
+      </div>
+    );
+  }
+}
+
+module.hot.accept();

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,0 +1,1 @@
+export const COOL_COLOR = 'pink';

--- a/src/hot.js
+++ b/src/hot.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { createProxy, getForceUpdate } from 'react-proxy';
+
+if (!window.__reactProxies) {
+  window.__reactProxies = {};
+}
+
+const forceUpdate = getForceUpdate(React);
+
+export default function hot(id) {
+  return function (ReactClass) {
+    if (window.__reactProxies[id]) {
+      console.info(`updating ${id}`);
+      const instances = window.__reactProxies[id].update(ReactClass);
+      requestAnimationFrame(() => {
+        instances.forEach(forceUpdate);
+      });
+    } else {
+      console.info(`creating ${id}`);
+      window.__reactProxies[id] = createProxy(ReactClass);
+    }
+
+    return window.__reactProxies[id].get();
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
+import { shouldAcceptFilename } from './transforms/hotify';
+if (shouldAcceptFilename(__filename)) {
+  module.hot.accept();
+}
+
+
 import React from 'react';
 import App from './App';
 

--- a/src/timers.js
+++ b/src/timers.js
@@ -1,0 +1,62 @@
+import { shouldAcceptFilename } from './transforms/hotify';
+if (shouldAcceptFilename(__filename)) {
+  module.hot.accept();
+}
+
+
+import React, { Component } from 'react';
+import { COOL_COLOR } from './colors';
+
+export class TimerA extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { counter: 0 };
+    this.interval = setInterval(() => this.tick(), 1000);
+  }
+
+  tick() {
+    this.setState({
+      counter: this.state.counter + 1
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    return (
+      <div style={{ color: COOL_COLOR }}>
+        <h2>{this.props.children}</h2>
+        <h3>TimerA state: {this.state.counter}</h3>
+      </div>
+    );
+  }
+}
+
+export class TimerB extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { counter: 0 };
+    this.interval = setInterval(() => this.tick(), 300);
+  }
+
+  tick() {
+    this.setState({
+      counter: this.state.counter + 1
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    return (
+      <div style={{ color: 'blue' }}>
+        <h2>{this.props.children}</h2>
+        <h3>TimerB state: {this.state.counter}</h3>
+      </div>
+    );
+  }
+}

--- a/src/transforms/catchRenderErrors.js
+++ b/src/transforms/catchRenderErrors.js
@@ -1,8 +1,10 @@
 import React from 'react';
 
-export default function catchRenderErrors({ filename, displayName }) {
-  return function transform(ReactClass) {
+export default function catchRenderErrors(filename, components) {
+  return componentId => ReactClass => {
+    const displayName = components[componentId].displayName || '<Unknown>';
     const originalRender = ReactClass.prototype.render;
+
     ReactClass.prototype.render = function tryRender() {
       try {
         return originalRender.apply(this, arguments);

--- a/src/transforms/catchRenderErrors.js
+++ b/src/transforms/catchRenderErrors.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function catchRenderErrors(filename, displayName) {
+export default function catchRenderErrors({ filename, displayName }) {
   return function transform(ReactClass) {
     const originalRender = ReactClass.prototype.render;
     ReactClass.prototype.render = function tryRender() {

--- a/src/transforms/catchRenderErrors.js
+++ b/src/transforms/catchRenderErrors.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function catchRenderErrors(filename, displayName) {
+  return function transform(ReactClass) {
+    const originalRender = ReactClass.prototype.render;
+    ReactClass.prototype.render = function tryRender() {
+      try {
+        return originalRender.apply(this, arguments);
+      } catch (err) {
+        console.error(err);
+        return React.createElement('div', {
+          style: {
+           backgroundColor: 'pink',
+           color: 'white'
+          }
+        }, `Error rendering ${displayName}: ${err.toString()}`);
+      }
+    };
+    return ReactClass;
+  }
+}

--- a/src/transforms/hotify.js
+++ b/src/transforms/hotify.js
@@ -7,8 +7,9 @@ if (!window.__reactProxies) {
 
 const forceUpdate = getForceUpdate(React);
 
-export default function hot(id) {
+export default function hotify(file, displayName) {
   return function (ReactClass) {
+    const id = `${file}:${displayName}`;
     if (window.__reactProxies[id]) {
       console.info(`updating ${id}`);
       const instances = window.__reactProxies[id].update(ReactClass);
@@ -16,7 +17,7 @@ export default function hot(id) {
         instances.forEach(forceUpdate);
       });
     } else {
-      console.info(`creating ${id}`);
+      console.info(`proxying ${id}`);
       window.__reactProxies[id] = createProxy(ReactClass);
     }
 

--- a/src/transforms/hotify.js
+++ b/src/transforms/hotify.js
@@ -3,12 +3,22 @@ import { createProxy, getForceUpdate } from 'react-proxy';
 
 if (!window.__reactProxies) {
   window.__reactProxies = {};
+  window.__reactFilenames = {};
 }
 
 const forceUpdate = getForceUpdate(React);
 
-export default function hotify({ filename, uniqueId, isInFunction }) {
-  return function (ReactClass) {
+export function shouldAcceptFilename(filename) {
+  return Object.keys(window.__reactFilenames).some(k => k.indexOf(filename) > -1);
+}
+
+export default function hotify(filename, components) {
+  if (Object.keys(components).some(k => !components[k].isInFunction)) {
+    window.__reactFilenames[filename] = true;
+  }
+
+  return uniqueId => ReactClass => {
+    const { isInFunction = false } = components[uniqueId];
     if (isInFunction) {
       return ReactClass;
     }

--- a/src/transforms/hotify.js
+++ b/src/transforms/hotify.js
@@ -7,20 +7,24 @@ if (!window.__reactProxies) {
 
 const forceUpdate = getForceUpdate(React);
 
-export default function hotify(file, displayName) {
+export default function hotify({ filename, uniqueId, isInFunction }) {
   return function (ReactClass) {
-    const id = `${file}:${displayName}`;
-    if (window.__reactProxies[id]) {
-      console.info(`updating ${id}`);
-      const instances = window.__reactProxies[id].update(ReactClass);
+    if (isInFunction) {
+      return ReactClass;
+    }
+
+    const globalUniqueId = `${filename}:${uniqueId}`;
+    if (window.__reactProxies[globalUniqueId]) {
+      console.info(`updating ${globalUniqueId}`);
+      const instances = window.__reactProxies[globalUniqueId].update(ReactClass);
       requestAnimationFrame(() => {
         instances.forEach(forceUpdate);
       });
     } else {
-      console.info(`proxying ${id}`);
-      window.__reactProxies[id] = createProxy(ReactClass);
+      console.info(`proxying ${globalUniqueId}`);
+      window.__reactProxies[globalUniqueId] = createProxy(ReactClass);
     }
 
-    return window.__reactProxies[id].get();
+    return window.__reactProxies[globalUniqueId].get();
   };
 }

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,0 +1,12 @@
+import hotify from './hotify';
+import catchRenderErrors from './catchRenderErrors';
+
+export default function (filename, displayName) {
+  return function (ReactClass) {
+    return catchRenderErrors(filename, displayName)(
+      hotify(filename, displayName)(
+        ReactClass
+      )
+    );
+  }
+}

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,10 +1,13 @@
 import hotify from './hotify';
 import catchRenderErrors from './catchRenderErrors';
 
-export default function (filename, displayName) {
-  return function (ReactClass) {
-    return catchRenderErrors(filename, displayName)(
-      hotify(filename, displayName)(
+export default function (filename, components) {
+  let wrapToCatch = catchRenderErrors(filename, components);
+  let wrapToHotify = hotify(filename, components);
+
+  return id => ReactClass => {
+    return wrapToCatch(id)(
+      wrapToHotify(id)(
         ReactClass
       )
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,10 @@ module.exports = {
     new webpack.NoErrorsPlugin()
   ],
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    alias: {
+      'my-custom-transform-see-webpack-config': path.join(__dirname, 'src', 'transforms')
+    }
   },
   module: {
     loaders: [{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,10 @@ var webpack = require('webpack');
 
 module.exports = {
   devtool: 'eval',
+  context: __dirname,
+  node: {
+    __filename: true
+  },
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.jsx?$/,
-      loaders: ['react-hot', 'babel'],
+      loaders: ['babel'],
       include: path.join(__dirname, 'src')
     }]
   }


### PR DESCRIPTION
It's not clear yet what React Hot Loader 2 is going to be, but [The Death of React Hot Loader](https://medium.com/@dan_abramov/the-death-of-react-hot-loader-765fa791d7c4) could give you some idea. In a nutshell, we're going to make it very slim and rethink crucial Webpack-independent parts.

This PR shows a playground of what React Hot Loader 2 should support. We don't actually even use RHL here: it's just [React Proxy](https://github.com/gaearon/react-proxy/) (new engine), a custom `hot()` decorator and a source code with `hot()` and `@hot` calls written by hand. You'll see that this enables many things that didn't work before:

* Hot reloading HOC code without losing state
* Hot reloading components wrapped in HOCs without losing state
* Defining several components in a single file
* Using autobind decorator

The tricky part is generating these `hot()` calls. We'll probably evolve proof-of-concept [babel-plugin-react-hotify](https://github.com/gaearon/babel-plugin-react-hotify) to support these scenarios, along with other scenarios like [babel-plugin-react-error-catcher](https://github.com/loggur/babel-plugin-react-error-catcher).

This may not be the best news for compile-to-JS languages like CoffeeScript, but I feel this is a step forward nevertheless because we're able to ditch the ugly exports rewriting, and enable a bunch of scenarios that didn't work before.

Feel free to play with it! More to come.