### PR TITLE
Don't use NoErrorsPlugin anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-eslint": "^3.1.9",
     "babel-loader": "^5.1.2",
     "eslint-plugin-react": "^2.3.0",
-    "react-hot-loader": "^1.2.7",
+    "react-hot-loader": "^1.3.0",
     "webpack": "^1.9.6",
     "webpack-dev-server": "^1.8.2"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   module: {
     loaders: [{


### PR DESCRIPTION
With React Hot Loader 1.3.0, `NoErrorsPlugin` is not needed anymore.
Plus, you can finally throw inside the module, and have the hot loading working after you fix the problem!