### PR TITLE
[BUGFIX] Return early if error

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ new WebpackDevServer(webpack(config), {
   historyApiFallback: true
 }).listen(3000, 'localhost', function (err, result) {
   if (err) {
-    console.log(err);
+    return console.log(err);
   }
 
   console.log('Listening at localhost:3000');


### PR DESCRIPTION
Removes logging that the server is listening when there is an error.