### PR TITLE
Add dist/ to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .DS_Store
+dist


### PR DESCRIPTION
Every time I run `webpack`, I get this in my terminal:

![image](https://cloud.githubusercontent.com/assets/3459374/9963348/8bb3b600-5e33-11e5-87f0-9397592fc158.png)

I'm not sure that's good. Maybe should we add `dist`-folder into `.gitignore`?