### PR TITLE
Update dependencies; replace React.render with ReactDOM.render

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,16 @@
   },
   "homepage": "https://github.com/gaearon/react-hot-boilerplate",
   "devDependencies": {
-    "babel-core": "^5.4.7",
-    "babel-eslint": "^3.1.9",
-    "babel-loader": "^5.1.2",
-    "eslint-plugin-react": "^2.3.0",
+    "babel-core": "^5.8.25",
+    "babel-eslint": "^4.1.3",
+    "babel-loader": "^5.3.2",
+    "eslint-plugin-react": "^3.6.2",
     "react-hot-loader": "^1.3.0",
-    "webpack": "^1.9.6",
-    "webpack-dev-server": "^1.8.2"
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.12.1"
   },
   "dependencies": {
-    "react": "^0.13.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import App from './App';
 
-React.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
I upgraded all dependencies using [npm-check-updates](https://www.npmjs.com/package/npm-check-updates). Then I added a new dependency `react-dom` and editted `index.js` (using `React.render` is deprecated in React 0.14 in favor of `ReactDOM.render`).