### PR TITLE
Use webpack middleware in v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "eslint-plugin-react": "^3.6.2",
     "react-hot-loader": "^3.0.0-beta.1",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.1"
+    "webpack-dev-middleware": "^1.6.1",
+    "webpack-dev-server": "^1.12.1",
+    "webpack-hot-middleware": "^2.10.0"
   },
   "dependencies": {
     "react": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "babel-preset-stage-0": "^6.0.15",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.6.2",
+    "express": "^4.13.4",
     "react-hot-loader": "^3.0.0-beta.1",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.6.1",
-    "webpack-dev-server": "^1.12.1",
     "webpack-hot-middleware": "^2.10.0"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ var webpack = require('webpack');
 var express = require('express');
 var devMiddleware = require('webpack-dev-middleware');
 var hotMiddleware = require('webpack-hot-middleware');
-
 var config = require('./webpack.config');
 
 var app = express();
@@ -20,7 +19,7 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-app.listen(3000, function(err) {
+app.listen(3000, function (err) {
   if (err) {
     return console.error(err);
   }

--- a/server.js
+++ b/server.js
@@ -1,14 +1,28 @@
+var path = require('path');
 var webpack = require('webpack');
-var WebpackDevServer = require('webpack-dev-server');
+var express = require('express');
+var devMiddleware = require('webpack-dev-middleware');
+var hotMiddleware = require('webpack-hot-middleware');
+
 var config = require('./webpack.config');
 
-new WebpackDevServer(webpack(config), {
+var app = express();
+var compiler = webpack(config);
+
+app.use(devMiddleware(compiler, {
   publicPath: config.output.publicPath,
-  hot: true,
-  historyApiFallback: true
-}).listen(3000, 'localhost', function (err, result) {
+  historyApiFallback: true,
+}));
+
+app.use(hotMiddleware(compiler));
+
+app.get('*', function (req, res) {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(3000, function(err) {
   if (err) {
-    return console.log(err);
+    return console.error(err);
   }
 
   console.log('Listening at http://localhost:3000/');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,7 @@ module.exports = {
   devtool: 'eval',
   entry: [
     'react-hot-loader/patch',
-    'webpack-dev-server/client?http://localhost:3000',
-    'webpack/hot/only-dev-server',
+    'webpack-hot-middleware/client',
     './src/index'
   ],
   output: {


### PR DESCRIPTION
This applies @adam-beck's work in #68 to the `next` branch to use webpack's middleware as per #65.
