### PR TITLE
Making the port 3000 configurable in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ open http://localhost:3000
 Now edit `src/App.js`.  
 Your changes will appear without reloading the browser like in [this video](http://vimeo.com/100010922).
 
+You can change the port of the local server in the `react-hot-boilerplate` config inside package.json
+
 ### Linting
 
 This boilerplate project includes React-friendly ESLint configuration.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/gaearon/react-hot-boilerplate/issues"
   },
   "homepage": "https://github.com/gaearon/react-hot-boilerplate",
+  "react-hot-boilerplate": {
+    "port": 3000
+  },
   "devDependencies": {
     "babel-core": "^6.0.20",
     "babel-eslint": "^4.1.3",

--- a/server.js
+++ b/server.js
@@ -1,15 +1,16 @@
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');
+var packageJson = require('./package.json');
 
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
   historyApiFallback: true
-}).listen(3000, 'localhost', function (err, result) {
+}).listen(packageJson[packageJson.name].port, 'localhost', function (err, result) {
   if (err) {
     return console.log(err);
   }
 
-  console.log('Listening at http://localhost:3000/');
+  console.log(`Listening at http://localhost:${packageJson[packageJson.name].port}/`);
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,12 @@
 var path = require('path');
 var webpack = require('webpack');
 
+var packageJson = require('./package.json');
+
 module.exports = {
   devtool: 'eval',
   entry: [
-    'webpack-dev-server/client?http://localhost:3000',
+    `webpack-dev-server/client?http://localhost:${packageJson[packageJson.name].port}`,
     'webpack/hot/only-dev-server',
     './src/index'
   ],


### PR DESCRIPTION
I had another project running in my port `3000` so, I felt free to change the port in server.js, then I realized I had to change it as well in `webpack.config.js` which made me think it would be a good idea to add an small feature to configure the port of the local server in a single spot.

My 2¢ here.  I hope it's useful @gaearon 
