### PR TITLE
Ensure initial render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,4 +12,5 @@ const render = Component =>
     rootEl
   );
 
+render(App);
 if (module.hot) module.hot.accept('./App', () => render(App));


### PR DESCRIPTION
Thanks for merging, was reviewing the new files to ensure there were no glaring errors, and I found one.

For some reason, the initial render wasn't included in `index.js` so it actually didn't work. Fixed here...

Sorry!