### PR TITLE
Avoid using return value from `ReactDOM.render()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,18 @@ import ReactDOM from 'react-dom';
 import App from './App';
 
 const rootEl = document.getElementById('root');
-const render = Component =>
+const render = (Component, callback) => {
   ReactDOM.render(
     <AppContainer>
       <Component />
     </AppContainer>,
-    rootEl
+    rootEl,
+    callback,
   );
+};
 
-render(App);
-if (module.hot) module.hot.accept('./App', () => render(App));
+render(App, () => {
+  if (module.hot) {
+    module.hot.accept('./App', () => render(App));
+  }
+});


### PR DESCRIPTION
According to the ReactDOM documentation at https://facebook.github.io/react/docs/react-dom.html#render, we should avoid using the return value from `ReactDOM.render()`:

> ReactDOM.render() currently returns a reference to the root ReactComponent instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root ReactComponent instance, the preferred solution is to attach a callback ref to the root element.